### PR TITLE
Add sparse matrix support for dot multiplication in function _sort_neighbourhood

### DIFF
--- a/backSPIN.py
+++ b/backSPIN.py
@@ -36,6 +36,7 @@
 
 from __future__ import division
 from numpy import *
+from scipy.sparse import csr_matrix
 import getopt
 import sys
 import os
@@ -114,8 +115,16 @@ def _sort_neighbourhood( dist_matrix, wid ):
     mat_size = dist_matrix.shape[0]
     #assert mat_size>2, 'Matrix is too small to be sorted'
     weights_mat = _calc_weights_matrix(mat_size, wid)
-    #Calculate the dot product (can be very slow for big mat_size)
-    mismatch_score = dot(dist_matrix, weights_mat)
+    mismatch_score = None
+    # Calculate the dot product using scipy's sparse method (speeds up the dot calculation)
+    # Convert to sparse matrices
+    weights_mat = csr_matrix(weights_mat)
+    dist_matrix = csr_matrix(dist_matrix)
+    # Calculate dot
+    mismatch_score = dist_matrix.dot(weights_mat)
+    # Convert to dense matrix
+    mismatch_score = mismatch_score.toarray()
+
     energy, target_permutation = mismatch_score.min(1), mismatch_score.argmin(1)
     max_energy = max(energy)
     #Avoid points that have the same target_permutation value
@@ -744,6 +753,7 @@ def usage():
               Normal spin accepts the parameters -T -S
               An axis value 0 to only sort genes (rows), 1 to only sort cells (columns) or 'both' for both
               must be passed
+              
        -v  
               Verbose. Print  to the stdoutput extra details of what is happening
 


### PR DESCRIPTION
Hi,

I edited one of the functions in backSPIN to add sparse matrix support to the dot calculation. In my machine, I've noticed a substantial speed increase when running big, sparse matrices derived from DropSeq (from two weeks and unfinished run to 2-3 days with the new version). Using the test data included in the package, the run time is ~10 minutes faster and the output files identical. 

I hope these changes help out other people :) It would be cool if it could be an optional feature, but I'm afraid I don't have the time to polish more the code. 

